### PR TITLE
Maintain the constructor's `length` property

### DIFF
--- a/newless.js
+++ b/newless.js
@@ -13,8 +13,15 @@
   var newless = function(constructor) {
     // in order to preserve constructor name, use the Function constructor
     var name = constructor.name || "";
+    
+    // create a list of arguments so that original constructor's `length` property is kept
+    var argumentList = [];
+    for (var i = constructor.length; i > 0; i--) {
+      argumentList.unshift("a" + i);
+    }
+    
     var newlessConstructor = Function("constructor, create",
-      "var newlessConstructor = function " + name + "() {" +
+      "var newlessConstructor = function " + name + "(" + argumentList.join(",") + ") {" +
         "var obj = this;" +
         // don't create a new object if we've already got one
         // (e.g. we were called with `new`)
@@ -30,7 +37,6 @@
     newlessConstructor.prototype = constructor.prototype;
     newlessConstructor.prototype.constructor = newlessConstructor;
     for (var property in constructor) {
-      console.log("Copy ", property)
       newlessConstructor[property] = constructor[property];
     }
     return newlessConstructor;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newless",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Modify constructors to function without `new`.",
   "main": "newless.js",
   "dependencies": {},

--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
   "version": "0.2.0",
   "description": "Modify constructors to function without `new`.",
   "main": "newless.js",
-  "dependencies": {},
+  "dependencies": {
+    "expect.js": "^0.3.1",
+    "mocha": "^2.2.0"
+  },
   "devDependencies": {
     "mocha": "~1.9.0",
     "expect.js": "~0.2.0"
@@ -18,7 +21,7 @@
   "keywords": [
     "constructor"
   ],
-  "author": "Rob Brackett",
+  "author": "Rob Brackett <rob@robbrackett.com>",
   "license": "BSD",
   "readmeFilename": "README.md",
   "gitHead": "20030ae9225b14eda740819146dd051efc5170b1"

--- a/test.js
+++ b/test.js
@@ -72,4 +72,10 @@ describe("newless", function() {
     expect(Construct.staticFunction).to.equal(BareConstructor.staticFunction);
     expect(Construct.someProperty).to.equal(15);
   });
+  
+  it("should preserve the constructor's `length` property.", function() {
+    var BareConstructor = function(a, b, c) {};
+    var Construct = newless(BareConstructor);
+    expect(Construct.length).to.equal(BareConstructor.length);
+  });
 });


### PR DESCRIPTION
Fixes #1. Creates a list of arguments to use when defining the newless constructor, thereby giving it the same length as the original constructor.

Also bump version to 0.2.0.
