### PR TITLE
Extract and preserve the original constructor's argument names.

### DIFF
--- a/newless.js
+++ b/newless.js
@@ -1,5 +1,8 @@
 (function(global) {
   "use strict";
+  
+  var STRIP_COMMENTS = /((\/\/.*$)|(\/\*[\s\S]*?\*\/))/mg;
+  var CAPTURE_ARGS = /^function\s*[^\(]*\(\s*([^\)]*)\)/m;
 
   // ulta-simple Object.create polyfill (only does half the job)
   var create = Object.create || (function() {
@@ -14,14 +17,12 @@
     // in order to preserve constructor name, use the Function constructor
     var name = constructor.name || "";
     
-    // create a list of arguments so that original constructor's `length` property is kept
-    var argumentList = [];
-    for (var i = constructor.length; i > 0; i--) {
-      argumentList.unshift("a" + i);
-    }
+    // extract the original constructor's arguments
+    var argumentList = Function.prototype.toString.call(constructor)
+      .replace(STRIP_COMMENTS, '').match(CAPTURE_ARGS)[1];
     
     var newlessConstructor = Function("constructor, create",
-      "var newlessConstructor = function " + name + "(" + argumentList.join(",") + ") {" +
+      "var newlessConstructor = function " + name + "(" + argumentList + ") {" +
         "var obj = this;" +
         // don't create a new object if we've already got one
         // (e.g. we were called with `new`)

--- a/test.js
+++ b/test.js
@@ -80,7 +80,7 @@ describe("newless", function() {
   });
   
   //---- Tests for ES 2015 classes. Skipped if syntax is not supported. ----
-  var classIt = it;
+  var ifClassSyntaxIt = it;
   try {
     var ES2015Class = Function("",
       "class ES2015Class {" +
@@ -90,12 +90,31 @@ describe("newless", function() {
   }
   catch(error) {
     console.log("This JS engine does not support class syntax; skipping related tests.");
-    var classIt = it.skip;
+    var ifClassSyntaxIt = it.skip;
   }
   
-  classIt("should work with ES2015 class syntax.", function() {
+  ifClassSyntaxIt("should work with ES2015 class syntax.", function() {
     var NewlessClass = newless(ES2015Class);
     var object = NewlessClass();
     expect(object.constructed).to.be.true
+  });
+  
+  //---- ES 2015 default args and destructuring. ----
+  it("Should work with destructuring.", function() {
+    var withDestructuredArgs = newless(function({a, b}, [c, d]){});
+    var signature = withDestructuredArgs.toString().replace(/\s/g, "").slice(0, 21);
+    expect(signature).to.equal("function({a,b},[c,d])");
+  });
+  
+  it("Should work with parentheses in default values.", function() {
+    var withFunnyArgs = newless(function(a="hello(name)"){});
+    var signature = withFunnyArgs.toString().replace(/\s/g, "").slice(0, 21);
+    expect(signature).to.equal("function(a=\"hello(name)\")");
+  });
+  
+  it("Should work with functions in default values.", function() {
+    var withFunnyArgs = newless(function(a=function(b){return b;}){});
+    var signature = withFunnyArgs.toString().replace(/\s/g, "").slice(0, 33);
+    expect(signature).to.equal("function(a=function(b){return b;})");
   });
 });


### PR DESCRIPTION
This mostly fixes #3, but it’s not really ready to go. It won't work with some kinds of default args in ES 2015, like function expressions or invocations, strings with parentheses, etc.

Example:

``` javascript
newless(function(value=Math.random()) { … });
newless(function(test=(input) => input * 2) { … });
```

While the above aren’t broadly supported _yet,_ they’re coming soon. It’s not ok to ship this if those expressions will break.
