### PR TITLE
Add real support for ES 2015 classes

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2013-2015, Rob Brackett
+Copyright (c) 2013-2016, Rob Brackett
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/README.md
+++ b/README.md
@@ -49,5 +49,5 @@ var user = User({name: "Jennifer"});
 
 ## License
 
-Newless is open source software. It is (c) 2013-2015 Rob Brackett and licensed under
+Newless is open source software. It is (c) 2013-2016 Rob Brackett and licensed under
 the BSD license. The full license text is in the `LICENSE` file.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,22 @@ var instance = MyObject("Hello");
 instance.something; // "Hello"
 ```
 
+And, of course, on new ES 6/2015 style classes:
+
+```js
+var MyObject = newless(class {
+  constructor(something) {
+    this.setSomething(something);
+  }
+  setSomething(value) {
+    this.something = value;
+  }
+});
+
+var instance = MyObject("Hello");
+instance.something; // "Hello"
+```
+
 You can also use it with existing constructors from other libraries without
 disrupting them:
 

--- a/newless.js
+++ b/newless.js
@@ -10,30 +10,63 @@
     }
   }());
 
+  // If an engine does not yet implement the spread operator, fall back to
+  // emulating it by constructing a function on the fly. That's pretty bad for
+  // performance, but I don't see a better way here.
+  try {
+    var newWithArguments = Function(
+      "constructor, args",
+      "return new constructor(...args);"
+    );
+  }
+  catch (error) {
+    newWithArguments = function(constructor, args) {
+      var instantiator = "'use strict'; return new constructor(";
+      for (var i = 0, len = args.length; i < len; i++) {
+        if (i > 0) {
+          instantiator += ",";
+        }
+        instantiator += "args[" + i + "]";
+      }
+      instantiator += ");";
+      return Function("constructor, args", instantiator)(constructor, args);
+    }
+  }
+
   var newless = function(constructor) {
     // in order to preserve constructor name, use the Function constructor
     var name = constructor.name || "";
-    
+
     // create a list of arguments so that original constructor's `length` property is kept
     var argumentList = [];
     for (var i = constructor.length; i > 0; i--) {
       argumentList.unshift("a" + i);
     }
-    
-    var newlessConstructor = Function("constructor, create",
+
+    var newlessConstructor = Function("constructor, create, newWithArguments",
       "var newlessConstructor = function " + name + "(" + argumentList.join(",") + ") {" +
-        "var obj = this;" +
-        // don't create a new object if we've already got one
-        // (e.g. we were called with `new`)
-        "if (!(this instanceof newlessConstructor)) {" +
-          "obj = create(newlessConstructor.prototype);" +
-        "}" +
-        // run the original constructor
-        "var returnValue = constructor.apply(obj, arguments);" +
-        // if we got back an object (and not null), use it as the return value
-        "return (typeof returnValue === 'object' && returnValue) || obj;" +
+        // ES2015 classes can't have their constructors called with `apply`, so
+        // we *must* use the `new` keyword. The only way to do this is either
+        // with the spread operator or with some really slow and funky code to
+        // emulate it. Unfortunately, some shipping engines implement classes
+        // but not spread, so try and limit our use of really slow emulation by
+        // only running it on things that appear to be classes.
+        // CAVEAT: this will break: `newless(SomeClass.prototype.constructor)`
+        (constructor.toString().indexOf("class ") === 0
+          ? "return newWithArguments(constructor, arguments);"
+          : ("var obj = this;" +
+            // don't create a new object if we've already got one
+            // (e.g. we were called with `new`)
+            "if (!(this instanceof newlessConstructor)) {" +
+              "obj = create(newlessConstructor.prototype);" +
+            "}" +
+            // run the original constructor
+            "var returnValue = constructor.apply(obj, arguments);" +
+            // if we got back an object (and not null), use it as the return value
+            "return (typeof returnValue === 'object' && returnValue) || obj;")
+        ) +
       "};" +
-      "return newlessConstructor;")(constructor, create);
+      "return newlessConstructor;")(constructor, create, newWithArguments);
     newlessConstructor.prototype = constructor.prototype;
     newlessConstructor.prototype.constructor = newlessConstructor;
     for (var property in constructor) {

--- a/newless.js
+++ b/newless.js
@@ -164,7 +164,7 @@
     // NOTE: *usually* the below will already be true, but we ensure it here.
     // Safari 9 requires this for the `super` keyword to work. Newer versions
     // of WebKit and other engines do not. Instead, they use the constructor's
-    // prototype chain (which correct by ES2015 spec) (see below).
+    // prototype chain (which is correct by ES2015 spec) (see below).
     newlessConstructor.prototype.constructor = constructor;
 
     // for ES2015 classes, we need to make sure the constructor's prototype

--- a/newless.js
+++ b/newless.js
@@ -20,18 +20,10 @@
   }());
 
   // If an engine does not yet implement the spread operator, emulate it by
-  // constructing a function on the fly. That's pretty bad for performance, but
-  // I don't see a better way here.
+  // binding the arguments passed to the constructor.
   function newWithArguments(constructor, args) {
-    var instantiator = "'use strict'; return new constructor(";
-    for (var i = 0, len = args.length; i < len; i++) {
-      if (i > 0) {
-        instantiator += ",";
-      }
-      instantiator += "args[" + i + "]";
-    }
-    instantiator += ");";
-    return Function("constructor, args", instantiator)(constructor, args);
+    var bindArgs = [null].concat([].slice.call(args));
+    return new (constructor.bind.apply(constructor, bindArgs));
   }
 
   var newless = function(constructor) {
@@ -48,10 +40,9 @@
       "var newlessConstructor = function " + name + "(" + argumentList.join(",") + ") {" +
         // ES2015 classes can't have their constructors called with `apply`, so
         // we *must* use the `new` keyword. The only way to do this is either
-        // with the spread operator or with some really slow and funky code to
-        // emulate it. Unfortunately, some shipping engines implement classes
-        // but not spread, so try and limit our use of really slow emulation by
-        // only running it on things that appear to be classes.
+        // with the spread operator or by emulating it with function.bind.
+        // Some shipping engines implement classes but not spread, so limit use
+        // of spread emulation by only running it on things that are classes.
         // NOTE: the only known implementations (V8 in NodeJS 4) that
         // support the class syntax but not spread happen to return the full
         // class declaration in `Class.toString()`, luckily allowing us to

--- a/newless.js
+++ b/newless.js
@@ -57,7 +57,8 @@
         // class declaration in `Class.toString()`, luckily allowing us to
         // differentiate. This isn't universal or by spec, though.
         (supportsSpread
-          ? "return new constructor(...arguments);"
+          // NOTE: the arguments object can't be used w/ spread in Firefox
+          ? "return new constructor(...([].slice.call(arguments)));"
           : (constructor.toString().indexOf("class") === 0
             ? "return newWithArguments(constructor, arguments);"
             : ("var obj = this;" +

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "expect.js": "~0.2.0"
   },
   "scripts": {
-    "test": "mocha --require test_helper_node.js"
+    "test": "mocha --require test/test_helper_node.js test/test.js"
   },
   "repository": {
     "type": "git",

--- a/test.js
+++ b/test.js
@@ -72,19 +72,21 @@ describe("newless", function() {
     expect(Construct.staticFunction).to.equal(BareConstructor.staticFunction);
     expect(Construct.someProperty).to.equal(15);
   });
-  
+
   it("should preserve the constructor's `length` property.", function() {
     var BareConstructor = function(a, b, c) {};
     var Construct = newless(BareConstructor);
     expect(Construct.length).to.equal(BareConstructor.length);
   });
-  
+
   //---- Tests for ES 2015 classes. Skipped if syntax is not supported. ----
   var classIt = it;
   try {
     var ES2015Class = Function("",
+      "\"use strict\";" +
       "class ES2015Class {" +
-        "constructor() { this.constructed = true; }" +
+        "constructor(a, b) { this.constructed = true; this.argA = a; this.argB = b; }" +
+        "something() { return true; }" +
       "};" +
       "return ES2015Class;")();
   }
@@ -92,10 +94,24 @@ describe("newless", function() {
     console.log("This JS engine does not support class syntax; skipping related tests.");
     var classIt = it.skip;
   }
-  
+
   classIt("should work with ES2015 class syntax.", function() {
     var NewlessClass = newless(ES2015Class);
     var object = NewlessClass();
     expect(object.constructed).to.be.true
+  });
+
+  classIt("should send correct arguments with ES2015 class syntax.", function() {
+    var NewlessClass = newless(ES2015Class);
+    var object = NewlessClass(1, 2);
+    expect(object.argA).to.equal(1);
+    expect(object.argB).to.equal(2);
+  });
+
+  classIt("should include all methods with ES2015 class syntax.", function() {
+    var NewlessClass = newless(ES2015Class);
+    var object = NewlessClass();
+    expect(object).to.have.property("something");
+    expect(object.something).to.be.a("function");
   });
 });

--- a/test/test-es2015-class.js
+++ b/test/test-es2015-class.js
@@ -1,0 +1,103 @@
+"use strict";
+
+describe("Newless ES 2015 classes", function() {
+
+  it("should work with ES2015 class syntax", function() {
+    class ES2015Class {
+      constructor() { this.constructed = true; }
+    }
+
+    var NewlessClass = newless(ES2015Class);
+    var object = NewlessClass();
+    expect(object).to.be.a(NewlessClass);
+    expect(object.constructed).to.be.true
+  });
+
+  it("should send correct arguments with ES2015 class syntax", function() {
+    class ES2015Class {
+      constructor(a, b) { this.argA = a; this.argB = b; }
+    }
+
+    var NewlessClass = newless(ES2015Class);
+    var object = NewlessClass(1, 2);
+    expect(object.argA).to.equal(1);
+    expect(object.argB).to.equal(2);
+  });
+
+  it("should include all methods with ES2015 class syntax", function() {
+    class ES2015Class {
+      constructor() {}
+      something() { return true; }
+      static somethingStatic() { return true; }
+    }
+
+    var NewlessClass = newless(ES2015Class);
+    var object = NewlessClass();
+    expect(object).to.have.property("something");
+    expect(object.something).to.be.a("function");
+    expect(NewlessClass.somethingStatic).to.be.a("function");
+  });
+
+  it("should work with inheritance in ES2015 class syntax", function() {
+    var instanceBase, instanceSub;
+
+    class BaseClass {
+      constructor() {
+        instanceBase = this;
+        this.baseInstanceProperty = true;
+      }
+      baseClassMethod() {}
+    }
+
+    var SubClass = newless(class SubClass extends BaseClass {
+      constructor() {
+        super();
+        instanceSub = this;
+        this.subInstanceProperty = true;
+      }
+      subClassMethod() {}
+    });
+
+    var object = SubClass();
+    expect(object).to.be.a(SubClass);
+    expect(object).to.be.a(BaseClass);
+    expect(object.baseClassMethod).to.be.a("function");
+    expect(object.subClassMethod).to.be.a("function");
+    expect(object).to.have.property("baseInstanceProperty");
+    expect(object).to.have.property("subInstanceProperty");
+    // no spurious instances are created.
+    expect(instanceSub).to.equal(instanceBase);
+  });
+
+  it("should be possible to inherit from a newless class", function() {
+    var instanceBase, instanceSub;
+
+    var BaseClass = newless(class BaseClass {
+      constructor() {
+        instanceBase = this;
+        this.baseInstanceProperty = true;
+      }
+      baseClassMethod() {}
+    });
+
+    var SubClass = newless(class SubClass extends BaseClass {
+      constructor() {
+        super();
+        instanceSub = this;
+        this.subInstanceProperty = true;
+      }
+      subClassMethod() {}
+    });
+
+    var object = SubClass();
+    expect(object).to.be.a(SubClass);
+    expect(object).to.be.a(BaseClass);
+    expect(object.baseClassMethod).to.be.a("function");
+    expect(object.subClassMethod).to.be.a("function");
+    expect(object).to.have.property("baseInstanceProperty");
+    expect(object).to.have.property("subInstanceProperty");
+    // no spurious instances are created.
+    expect(instanceSub).to.equal(instanceBase);
+  });
+
+});

--- a/test/test-es2015-class.js
+++ b/test/test-es2015-class.js
@@ -13,6 +13,17 @@ describe("Newless ES 2015 classes", function() {
     expect(object.constructed).to.be.true
   });
 
+  it("should work with the `new keyword` with ES2015 class syntax", function() {
+    class ES2015Class {
+      constructor() { this.constructed = true; }
+    }
+
+    var NewlessClass = newless(ES2015Class);
+    var object = new NewlessClass();
+    expect(object).to.be.a(NewlessClass);
+    expect(object.constructed).to.be.true
+  });
+
   it("should send correct arguments with ES2015 class syntax", function() {
     class ES2015Class {
       constructor(a, b) { this.argA = a; this.argB = b; }
@@ -90,6 +101,37 @@ describe("Newless ES 2015 classes", function() {
     });
 
     var object = SubClass();
+    expect(object).to.be.a(SubClass);
+    expect(object).to.be.a(BaseClass);
+    expect(object.baseClassMethod).to.be.a("function");
+    expect(object.subClassMethod).to.be.a("function");
+    expect(object).to.have.property("baseInstanceProperty");
+    expect(object).to.have.property("subInstanceProperty");
+    // no spurious instances are created.
+    expect(instanceSub).to.equal(instanceBase);
+  });
+
+  it("should be possible for a non-newless class to inherit from a newless class", function() {
+    var instanceBase, instanceSub;
+
+    var BaseClass = newless(class BaseClass {
+      constructor() {
+        instanceBase = this;
+        this.baseInstanceProperty = true;
+      }
+      baseClassMethod() {}
+    });
+
+    class SubClass extends BaseClass {
+      constructor() {
+        super();
+        instanceSub = this;
+        this.subInstanceProperty = true;
+      }
+      subClassMethod() {}
+    };
+
+    var object = new SubClass();
     expect(object).to.be.a(SubClass);
     expect(object).to.be.a(BaseClass);
     expect(object.baseClassMethod).to.be.a("function");

--- a/test/test.html
+++ b/test/test.html
@@ -3,17 +3,17 @@
 <head>
   <meta charset="utf-8">
   <title>Newless Tests</title>
-  <link rel="stylesheet" href="node_modules/mocha/mocha.css" />
+  <link rel="stylesheet" href="../node_modules/mocha/mocha.css" />
 </head>
 <body>
   <div id="mocha"></div>
-  <script src="node_modules/expect.js/index.js"></script>
-  <script src="node_modules/mocha/mocha.js"></script>
+  <script src="../node_modules/expect.js/index.js"></script>
+  <script src="../node_modules/mocha/mocha.js"></script>
   <script>mocha.setup('bdd')</script>
 
-  <script src="newless.js"></script>
+  <script src="../newless.js"></script>
   <script src="test.js"></script>
-  
+
   <script>
     mocha.checkLeaks();
     mocha.run();

--- a/test/test_helper_node.js
+++ b/test/test_helper_node.js
@@ -1,0 +1,2 @@
+global.newless = require("../newless");
+global.expect = require("expect.js");

--- a/test_helper_node.js
+++ b/test_helper_node.js
@@ -1,2 +1,0 @@
-global.newless = require("./newless");
-global.expect = require("expect.js");


### PR DESCRIPTION
In ES2015, class constructors are special in that calling them without the `new` keyword triggers an exception. This is also true when using `call` and `apply` on them. Unfortunately, that means newless's current technique for constructing objects won't work when you use the actual class syntax like so:

```
var Point = newless(class Point {
    constructor(x, y) {
        this.x = x;
        this.y = y;
    }
});
```

SO! This change adds support for this by actually using the `new` keyword when a class is involved. To do so, it uses the spread operator or, if the spread operator isn't supported, by creating a function that will call `new` with the proper arguments. That fallback is pretty slow and bad, though — it means creating a throwaway function and calling it every time an object is constructed. Ugh. But I can't think of another workable approach. And having some approach there is critical since some major shipping environments (e.g. NodeJS 4) have classes but not the spread operator.

To mitigate the performance problem, this patch also attempts to determine if it is dealing with a class or a normal function by calling `toString()` on the function it is working with. This works the vast majority of the time, but it's worth noting that it can fail:
- If `Function.prototype.toString` has been overwritten.
- If newless is called on the class's constructor rather than the class itself, e.g:
  `newless(SomeClass.prototype.constructor)` rather than `newless(SomeClass)`.

Anyway, this is far from perfect, but I think it’s the best that can be done at the moment.
