### PR TITLE
Improve support for functions inheriting from classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ var user = User({name: "Jennifer"});
 
 When an ES 2015 class is wrapped with Newless, you should be somewhat careful in trying to call it with a custom context via `Class.call(customContext)` or `Class.apply(customContext)`. Because of limitations imposed by the class syntax, calling a Newless ES 2015 class will always return a new object. If the custom context you provide is one that includes the Newless class anywhere in its prototype chain, the returned object will have the exact same prototype chain as the custom context, but it will be separate object.
 
-This is generally only an issue when creating a function constructor that inherits from a class constructor. Inheriting functions constructors usually works like this:
+This is generally only an issue when creating a function constructor that inherits from a class constructor. Inheriting function constructors usually works like this:
 
 ```js
 function SubConstructor() {
@@ -96,7 +96,7 @@ function SubConstructor() {
 SubConstructor.prototype = Object.create(SuperConstructor.prototype);
 ```
 
-Note that, instead of working with `this`, you work with the return value of calling `SuperConstructor`. If you already code inheritance this way, everything will work 100% fine. If you don’t this will *mostly* work fine, but you could occasionally hit issues where `this` must be the same object in sub- and super-constructors.
+Note that, instead of working with `this`, you work with the return value of calling `SuperConstructor`. If you already code inheritance this way, everything works fine. If you don’t, making this change could help you avoid some rare edge cases where you might run into trouble.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ var user = User({name: "Jennifer"});
 
 ## Caveats
 
+*Note: this description is long only because the caveat is uncommon and nuanced. In most cases, it shouldn’t affect you. :)*
+
 When an ES 2015 class is wrapped with Newless, you should be somewhat careful in trying to call it with a custom context via `Class.call(customContext)` or `Class.apply(customContext)`. Because of limitations imposed by the class syntax, calling a Newless ES 2015 class will always return a new object. If the custom context you provide is one that includes the Newless class anywhere in its prototype chain, the returned object will have the exact same prototype chain as the custom context, but it will be separate object.
 
 This is generally only an issue when creating a function constructor that inherits from a class constructor. Inheriting functions constructors usually works like this:

--- a/test/test-es2015-class.js
+++ b/test/test-es2015-class.js
@@ -142,4 +142,22 @@ describe("Newless ES 2015 classes", function() {
     expect(instanceSub).to.equal(instanceBase);
   });
 
+  it("should update a function's `this` when inheriting from a class constructor", function() {
+    // NOTE: this does *not* mean `this` in SubClass === `this` in BaseClass.
+    // We *are* trying to come as close to that as we can, though.
+    
+    var BaseClass = newless(class {
+      constructor() {
+        this.baseInstanceProperty = true;
+      }
+    });
+
+    var SubClass = function() {
+      BaseClass.call(this);
+    };
+    SubClass.prototype = Object.create(BaseClass.prototype);
+
+    expect(new SubClass()).to.have.property("baseInstanceProperty");
+  });
+
 });

--- a/test/test.js
+++ b/test/test.js
@@ -52,8 +52,9 @@ describe("Newless functions", function() {
   });
 
   it("should preserve a constructor's name", function() {
-    var Construct = newless(function Maker() {});
-    expect(Construct.name).to.equal("Maker");
+    var implementation = function Maker() {};
+    var Construct = newless(implementation);
+    expect(Construct.name).to.equal(implementation.name);
   });
 
   it("should preserve a constructor's displayName", function() {


### PR DESCRIPTION
This adds a small workaround to improve the experience for users writing functions that inherit from ES 2015 classes wrapped in newless, as noted in https://github.com/Mr0grog/newless/pull/5#issuecomment-199492179

The basic idea here is that, if the constructor was called with a custom context like so:

``` js
let BaseClass = newless(class { constructor() { this.x = "from base"; } });

var SubClass = function() {
  BaseClass.call(this);
};
SubClass.prototype = Object.create(BaseClass.prototype);
```

We update `SubClass`’s `this` to use `BaseClass`’s `this` as its prototype.

Normally, the prototype chain for `SubClass`’s `this` would normally look like:

```
- {new object}
  └ SubClass.prototype
     └ BaseClass.prototype
```

But now it will be:

```
- {new object}
  └ {new object created when calling BaseClass}
     └ SubClass.prototype
        └ BaseClass.prototype
```

This isn’t perfect, but I think it’s the best we can do, given that a) we _have_ to create a new object when calling a constructor created with class-syntax and b) we cannot change the object `this` references in the calling function (`SubClass` in the above example).

We still return the actual newly constructed instance, so a smarter function implementation will work fine with no caveats at all:

``` js
let BaseClass = newless(class { constructor() { this.x = "from base"; } });

var SubClass = function() {
  var instance = BaseClass.call(this);
  return instance;
};
SubClass.prototype = Object.create(BaseClass.prototype);
```
